### PR TITLE
Update install-claude-desktop.sh to use version 0.9.2

### DIFF
--- a/install-claude-desktop.sh
+++ b/install-claude-desktop.sh
@@ -100,7 +100,7 @@ if ! check_command "electron"; then
 fi
 
 # Extract version from the installer filename
-VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.9.1/')
+VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.9.2/')
 PACKAGE_NAME="claude-desktop"
 ARCHITECTURE="amd64"
 MAINTAINER="Claude Desktop Linux Maintainers"


### PR DESCRIPTION
Claude installer now contains version 0.9.2.

Until this is merged, the following can be run to patch the installer script:

```
wget -O- https://raw.githubusercontent.com/emsi/claude-desktop/refs/heads/main/install-claude-desktop.sh | sed 's/0\.9\.1/0.9.2/g' | bash
```

or the installer script in this branch can be run directly:

```
wget -O- https://raw.githubusercontent.com/srstsavage/claude-desktop/refs/heads/update-claude-0.9.2/install-claude-desktop.sh | bash
```