### PR TITLE
Fix version extraction in install script

### DIFF
--- a/install-claude-desktop.sh
+++ b/install-claude-desktop.sh
@@ -99,8 +99,7 @@ if ! check_command "electron"; then
     echo "Electron installed successfully"
 fi
 
-# Extract version from the installer filename
-VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.9.3/')
+# Version will be extracted from nupkg filename after extraction
 PACKAGE_NAME="claude-desktop"
 ARCHITECTURE="amd64"
 MAINTAINER="Claude Desktop Linux Maintainers"
@@ -157,7 +156,17 @@ if ! 7z x -y "$CLAUDE_EXE"; then
     exit 1
 fi
 
-if ! 7z x -y "AnthropicClaude-$VERSION-full.nupkg"; then
+# Extract version from nupkg filename
+NUPKG_FILE=$(ls AnthropicClaude-*-full.nupkg 2>/dev/null | head -1)
+if [ -n "$NUPKG_FILE" ]; then
+    VERSION=$(echo "$NUPKG_FILE" | sed -n 's/AnthropicClaude-\([0-9]\+\.[0-9]\+\.[0-9]\+\)-full\.nupkg/\1/p')
+    echo "✓ Version extracted from nupkg filename: $VERSION"
+else
+    echo "❌ No nupkg file found"
+    exit 1
+fi
+
+if ! 7z x -y "$NUPKG_FILE"; then
     echo "❌ Failed to extract nupkg"
     exit 1
 fi


### PR DESCRIPTION
@emsi Thank you for creating and mantaining tool!

Extract version dynamically from nupkg filename instead of hardcoding it. 
This ensures the correct version is used when building the .deb package.